### PR TITLE
provide hovers + enhance heuristics for definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "0.0.0-development",
   "title": "Basic code intelligence",
   "description": "Provides basic code intelligence for all languages using the Sourcegraph search API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sourcegraph/sourcegraph-basic-code-intel"
+  },
   "activationEvents": [
     "*"
   ],

--- a/package.json
+++ b/package.json
@@ -42,15 +42,15 @@
         "category": "Basic code intel"
       },
       {
-        "id": "basicCodeIntel.toggleSymbols",
+        "id": "basicCodeIntel.toggleCrossRepository",
         "command": "updateConfiguration",
         "commandArguments": [
           [
-            "basicCodeIntel.definition.symbols"
+            "basicCodeIntel.definition.crossRepository"
           ],
-          "${((config.basicCodeIntel.definition.symbols == \"local\") || (config.basicCodeIntel.definition.symbols == \"always\")) && \"never\" || \"local\"}"
+          "${!config.basicCodeIntel.definition.crossRepository}"
         ],
-        "title": "${((config.basicCodeIntel.definition.symbols == \"local\") || (config.basicCodeIntel.definition.symbols == \"always\")) && \"Disable\" || \"Enable\"} hints from ctags",
+        "title": "${config.basicCodeIntel.definition.crossRepository && \"Disable\" || \"Enable\"} cross-repository definitions",
         "category": "Basic code intel"
       },
       {
@@ -80,7 +80,7 @@
           "when": "resource"
         },
         {
-          "action": "basicCodeIntel.toggleSymbols",
+          "action": "basicCodeIntel.toggleCrossRepository",
           "when": "resource"
         },
         {
@@ -103,14 +103,9 @@
           "type": "boolean",
           "default": false
         },
-        "basicCodeIntel.definition.symbols": {
-          "type": "string",
-          "description": "Whether to use symbol search to complete goto definition requests. 'Local' means issue a symbol search locally and if none are found, fall back to text search globally.",
-          "enum": [
-            "never",
-            "local",
-            "always"
-          ]
+        "basicCodeIntel.definition.crossRepository": {
+          "type": "boolean",
+          "description": "Whether to try to find definitions in all repositories, not just the current repository. If set to true, it uses symbol search across all repositories to complete go-to-definition requests."
         },
         "basicCodeIntel.debug.traceSearch": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,20 @@
         }
       },
       {
+        "id": "basicCodeIntel.toggleHover",
+        "command": "updateConfiguration",
+        "commandArguments": [
+          [
+            "basicCodeIntel.hover"
+          ],
+          "${!config.basicCodeIntel.hover}",
+          null,
+          "json"
+        ],
+        "title": "${config.basicCodeIntel.hover && \"Disable\" || \"Enable\"} fuzzy hovers",
+        "category": "Basic code intel"
+      },
+      {
         "id": "basicCodeIntel.toggleSymbols",
         "command": "updateConfiguration",
         "commandArguments": [
@@ -59,6 +73,10 @@
       "commandPalette": [
         {
           "action": "basicCodeIntel.toggle",
+          "when": "resource"
+        },
+        {
+          "action": "basicCodeIntel.toggleHover",
           "when": "resource"
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,6 +50,24 @@ export function activate(ctx: sourcegraph.ExtensionContext = DUMMY_CTX): void {
 
     ctx.subscriptions.add(
         reregisterWhenEnablementChanges(() =>
+            sourcegraph.languages.registerHoverProvider(DOCUMENT_SELECTOR, {
+                provideHover: (doc, pos) => {
+                    if (
+                        !sourcegraph.configuration.get<Settings>().value[
+                            'basicCodeIntel.hover'
+                        ]
+                    ) {
+                        return null
+                    }
+                    return enabledOrNull(() =>
+                        observableOrPromiseCompat(h.hover(doc, pos))
+                    )
+                },
+            })
+        )
+    )
+    ctx.subscriptions.add(
+        reregisterWhenEnablementChanges(() =>
             sourcegraph.languages.registerDefinitionProvider(
                 DOCUMENT_SELECTOR,
                 {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,8 +125,8 @@ function reregisterWhenEnablementChanges(
                 (a, b) =>
                     Boolean(a['basicCodeIntel.enabled']) ===
                         Boolean(b['basicCodeIntel.enabled']) &&
-                    a['basicCodeIntel.definition.symbols'] ===
-                        b['basicCodeIntel.definition.symbols']
+                    a['basicCodeIntel.definition.crossRepository'] ===
+                        b['basicCodeIntel.definition.crossRepository']
             ),
             map(() => {
                 if (registration) {

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -4,7 +4,7 @@ import { Result } from './api'
 import { Position } from 'sourcegraph'
 
 interface SearchTest {
-    symbols?: 'local' | 'always'
+    crossRepo?: boolean
     doc: {
         uri: string
         text: string
@@ -18,7 +18,7 @@ describe('search requests', () => {
     it('makes correct search requests for goto definition', async () => {
         const tests: SearchTest[] = [
             {
-                symbols: undefined,
+                crossRepo: undefined,
                 doc: {
                     uri: 'git://github.com/foo/bar?rev#file.c',
                     text: 'token',
@@ -28,7 +28,7 @@ describe('search requests', () => {
                 ],
             },
             {
-                symbols: 'always',
+                crossRepo: true,
                 doc: {
                     uri: 'git://github.com/foo/bar?rev#file.c',
                     text: 'token',
@@ -39,7 +39,7 @@ describe('search requests', () => {
                 ],
             },
             {
-                symbols: 'local',
+                crossRepo: false,
                 doc: {
                     uri: 'git://github.com/foo/bar?rev#file.c',
                     text: 'token',
@@ -65,7 +65,7 @@ describe('search requests', () => {
                     text: test.doc.text,
                 },
                 { line: 0, character: 0 } as Position,
-                test.symbols
+                test.crossRepo
             )
             assert.deepStrictEqual(test.expSearchQueries, searchQueries)
         }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -200,7 +200,6 @@ export class Handler {
             .get<Settings>()
             .get('basicCodeIntel.definition.crossRepository')
     ): Promise<sourcegraph.Location[] | null> {
-
         const lines = doc.text.split('\n')
         const line = lines[pos.line]
         let end = line.length

--- a/src/memoizeAsync.ts
+++ b/src/memoizeAsync.ts
@@ -1,0 +1,26 @@
+/**
+ * Creates a function that memoizes the async result of func.
+ * If the promise rejects, the value will not be cached.
+ *
+ * @param resolver If resolver provided, it determines the cache key for storing the result based on
+ * the first argument provided to the memoized function.
+ */
+export function memoizeAsync<P, T>(
+    func: (params: P) => Promise<T>,
+    resolver?: (params: P) => string
+): (params: P, force?: boolean) => Promise<T> {
+    const cache = new Map<string, Promise<T>>()
+    return (params: P, force = false) => {
+        const key = resolver ? resolver(params) : params.toString()
+        const hit = cache.get(key)
+        if (!force && hit) {
+            return hit
+        }
+        const p = func(params).catch(e => {
+            cache.delete(key)
+            throw e
+        })
+        cache.set(key, p)
+        return p
+    }
+}


### PR DESCRIPTION
**Depends on https://github.com/sourcegraph/sourcegraph/pull/1313.**

If `basicCodeIntel.hover` is enabled in user settings, this extension will provide hovers consisting of:

- the best-guess definition line's code, cleaned up a bit (e.g., removing trailing `:`s)
- the docstring before or after the definition line

It only shows a hover if the definition location can be found using symbols. If no results are found using symbols, it does not fall back to text search for generating hover contents because that is too inaccurate.

The `basicCodeIntel.hover` setting is off by default.

### Screenshots of hovers on various languages

![screenshot from 2018-12-08 02-21-21](https://user-images.githubusercontent.com/1976/49684970-62863f80-fa90-11e8-9178-1b69691ccc23.png)
![screenshot from 2018-12-08 02-13-33](https://user-images.githubusercontent.com/1976/49684971-62863f80-fa90-11e8-8113-27c6807fd3df.png)
![screenshot from 2018-12-08 02-11-55](https://user-images.githubusercontent.com/1976/49684972-62863f80-fa90-11e8-86b4-c7694fdac643.png)
![screenshot from 2018-12-08 01-40-26](https://user-images.githubusercontent.com/1976/49684973-62863f80-fa90-11e8-930c-041e826069bc.png)
![screenshot from 2018-12-08 01-22-51](https://user-images.githubusercontent.com/1976/49684974-631ed600-fa90-11e8-9812-6853929b5d33.png)
![screenshot from 2018-12-08 01-08-49](https://user-images.githubusercontent.com/1976/49684975-631ed600-fa90-11e8-8fb1-0c253edfa515.png)
