### PR TITLE
feat: enable defs/refs/hovers by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,12 @@
         "basicCodeIntel.enabled": {
           "description": "Use fuzzy text searches and ctags to provide code intelligence (definitions and references).",
           "type": "boolean",
-          "default": false
+          "default": true
+        },
+        "basicCodeIntel.hover": {
+          "description": "Show hover definitions and documentation based on fuzzy text searches and ctags.",
+          "type": "boolean",
+          "default": true
         },
         "basicCodeIntel.definition.crossRepository": {
           "type": "boolean",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -120,9 +120,9 @@ function resultToLocation(res: Result): sourcegraph.Location {
  * @see package.json contributes.configuration section for the configuration schema.
  */
 export interface Settings {
-    ['basicCodeIntel.enabled']?: boolean
+    ['basicCodeIntel.enabled']?: boolean // default true
     ['basicCodeIntel.definition.crossRepository']?: boolean
-    ['basicCodeIntel.hover']?: boolean
+    ['basicCodeIntel.hover']?: boolean // default true
     ['basicCodeIntel.debug.traceSearch']?: boolean
 }
 


### PR DESCRIPTION
Previously, all functionality was disabled by default (except for command palette actions). This meant that users needed to explicitly run "Enable fuzzy defs/refs" and "Enable fuzzy hovers" in the command palette after enabling this extension. It is easy for users to not know this was necessary and therefore not understand how to use this extension. Now, it enables them by default.

fix https://github.com/sourcegraph/sourcegraph/issues/1779