### PR TITLE
Add an "Imprecise results" label to references

### DIFF
--- a/generator/src/main.ts
+++ b/generator/src/main.ts
@@ -104,7 +104,7 @@ function main(): void {
         )
         shell.sed(
             '-i',
-            /"description": ".*"/,
+            /^  "description": ".*"/,
             `"description": "Provides basic code intelligence for ${stylized} using the Sourcegraph search API"`,
             'package.json'
         )
@@ -112,6 +112,26 @@ function main(): void {
             '-i',
             /"url": ".*"/,
             `"url": "https://github.com/sourcegraph/sourcegraph-${languageID}"`,
+            'package.json'
+        )
+        shell.sed(
+            '-i',
+            /GENERATOR:IMPRECISE_RESULTS_URL/,
+            langSpec.hasLanguageServer
+                ? `https://github.com/sourcegraph/sourcegraph-${
+                      langSpec.handlerArgs.languageID
+                  }`
+                : `https://github.com/sourcegraph/sourcegraph-${
+                      langSpec.handlerArgs.languageID
+                  }#limitations`,
+            'package.json'
+        )
+        shell.sed(
+            '-i',
+            /"These locations are computed using heuristics.*"/,
+            langSpec.hasLanguageServer
+                ? `These locations are computed using heuristics. Use a language server for precise results."`
+                : `These locations are computed using heuristics.`,
             'package.json'
         )
         shell.sed('-i', /\$LANGNAME\b/, languageID, 'README.md')

--- a/languages.ts
+++ b/languages.ts
@@ -5,6 +5,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 export type LanguageSpec = {
     handlerArgs: Omit<HandlerArgs, 'sourcegraph'>
     stylized: string
+    hasLanguageServer?: boolean
 }
 
 const cStyleBlock = {
@@ -59,6 +60,7 @@ export const languages: LanguageSpec[] = [
             commentStyle: cStyle,
         },
         stylized: 'TypeScript',
+        hasLanguageServer: true,
     },
     {
         handlerArgs: {
@@ -75,6 +77,7 @@ export const languages: LanguageSpec[] = [
             },
         },
         stylized: 'Python',
+        hasLanguageServer: true,
     },
     {
         handlerArgs: {
@@ -98,6 +101,7 @@ export const languages: LanguageSpec[] = [
             },
         },
         stylized: 'Go',
+        hasLanguageServer: true,
     },
     {
         handlerArgs: {

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/basic-code-intel",
-  "version": "6.0.5",
+  "version": "6.0.6",
   "description": "Common library for providing basic code intelligence in Sourcegraph extensions",
   "repository": {
     "type": "git",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -12,6 +12,8 @@ export function activateBasicCodeIntel(
     ): void {
         const h = new Handler(args)
 
+        sourcegraph.internal.updateContext({ isImprecise: true })
+
         ctx.subscriptions.add(
             sourcegraph.languages.registerHoverProvider(
                 documentSelector(h.fileExts),

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -4,13 +4,15 @@ import { Handler, documentSelector, HandlerArgs } from './handler'
 // No-op for Sourcegraph versions prior to 3.0-preview
 const DUMMY_CTX = { subscriptions: { add: (_unsubscribable: any) => void 0 } }
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
 export function activateBasicCodeIntel(
-    args: HandlerArgs
+    args: Omit<HandlerArgs, 'sourcegraph'>
 ): (ctx: sourcegraph.ExtensionContext) => void {
     return function activate(
         ctx: sourcegraph.ExtensionContext = DUMMY_CTX
     ): void {
-        const h = new Handler(args)
+        const h = new Handler({ ...args, sourcegraph })
 
         sourcegraph.internal.updateContext({ isImprecise: true })
 

--- a/template/package.json
+++ b/template/package.json
@@ -18,6 +18,28 @@
     "*"
   ],
   "contributes": {
+    "actions": [
+      {
+        "id": "impreciseResults",
+        "title": "Imprecise results",
+        "command": "open",
+        "commandArguments": [
+          "GENERATOR:IMPRECISE_RESULTS_URL"
+        ],
+        "actionItem": {
+          "label": "Imprecise results",
+          "description": "These locations are computed using heuristics. (If available:) use a language server for precise results."
+        }
+      }
+    ],
+    "menus": {
+      "panel/toolbar": [
+        {
+          "action": "impreciseResults",
+          "when": "isImprecise"
+        }
+      ]
+    },
     "configuration": {
       "title": "Basic code intelligence settings",
       "properties": {

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -4,6 +4,6 @@ import * as spec from '../../languages'
 
 export function activate(ctx: sourcegraph.ExtensionContext): void {
     for (const language of spec.languages) {
-        activateBasicCodeIntel({ ...language.handlerArgs, sourcegraph })(ctx)
+        activateBasicCodeIntel(language.handlerArgs)(ctx)
     }
 }


### PR DESCRIPTION
Users are often times confused why imprecise references are shown in the references panel after clicking "Find references". This happens for languages that do not have a language server and for Sourcegraph instances that don't have a language server deployed.

This adds an "Imprecise results" label (technically an action) to the references panel. Here's what it looks like when you haven't set up a language server yet:

![image](https://user-images.githubusercontent.com/1387653/53997652-dff23800-40f1-11e9-89c8-24289d571644.png)

When there is no language server for the current language, the second sentence is dropped.

When you have the `{go,typescript,python}.serverUrl` set, the label is not shown.