### PR TITLE
Fix JSON.stringify on circular value

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/basic-code-intel",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Common library for providing basic code intelligence in Sourcegraph extensions",
   "repository": {
     "type": "git",

--- a/package/src/api.ts
+++ b/package/src/api.ts
@@ -216,5 +216,5 @@ const queryGraphQL = memoizeAsync(
             vars
         )
     },
-    arg => JSON.stringify(arg)
+    arg => JSON.stringify({ query: arg.query, vars: arg.vars })
 )


### PR DESCRIPTION
This used to `JSON.stringify` something that contained `sourcegraph`, which must have some circular references. I believe this is causing https://github.com/sourcegraph/sourcegraph-python/issues/7.