### PR TITLE
Lowercase "l" in "Programming languages"

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/sourcegraph/sourcegraph-somelang"
   },
   "categories": [
-    "Programming Languages"
+    "Programming languages"
   ],
   "tags": [
     "fuzzy"


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/2700