### PR TITLE
Add debug mode

### DIFF
--- a/package/src/api.ts
+++ b/package/src/api.ts
@@ -18,6 +18,10 @@ export interface Result {
         character: number
     }
     preview?: string // only for text search results
+    symbolName?: string
+    symbolKind?: string
+    containerName?: string
+    fileLocal?: boolean
 }
 
 export class API {
@@ -64,6 +68,7 @@ export class API {
                     symbols {
                       name
                       containerName
+                      fileLocal
                       url
                       kind
                       location {
@@ -115,6 +120,10 @@ export class API {
                             line: sym.location.range.end.line,
                             character: sym.location.range.end.character,
                         },
+                        symbolName: sym.name,
+                        symbolKind: sym.kind,
+                        containerName: sym.containerName,
+                        fileLocal: sym.fileLocal,
                     })
                 }
             }
@@ -200,7 +209,7 @@ export function parseUri(
 }
 
 // TODO(sqs): this will never release the memory of the cached responses; use an LRU cache or similar.
-const queryGraphQL = memoizeAsync(
+export const queryGraphQL = memoizeAsync(
     async ({
         query,
         vars,


### PR DESCRIPTION
When you set `"codeintel.debug": true`, each line that contains a symbol definition will be highlighted:

![image](https://user-images.githubusercontent.com/1387653/54485782-56064580-483c-11e9-9f9d-1ad6f0879b93.png)
