### PR TITLE
Only query for fileLocal if codeintel.debug is specified

### DIFF
--- a/package/src/api.ts
+++ b/package/src/api.ts
@@ -38,10 +38,16 @@ export class API {
     /**
      * search returns the list of results fetched from the Sourcegraph search API.
      */
-    async search(searchQuery: string): Promise<Result[]> {
+    async search({
+        query,
+        fileLocal = false,
+    }: {
+        query: string
+        fileLocal?: boolean
+    }): Promise<Result[]> {
         if (this.traceSearch) {
             console.log('%c' + 'Search', 'font-weight:bold;', {
-                query: searchQuery,
+                query,
             })
         }
 
@@ -68,7 +74,7 @@ export class API {
                     symbols {
                       name
                       containerName
-                      fileLocal
+                      ${fileLocal ? 'fileLocal' : ''}
                       url
                       kind
                       location {
@@ -97,7 +103,7 @@ export class API {
               }
             }
           }`
-        const graphqlVars = { query: searchQuery }
+        const graphqlVars = { query }
 
         const respObj = await queryGraphQL({
             query: graphqlQuery,

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -628,8 +628,9 @@ export class Handler {
                 this.sourcegraph.internal.sourcegraphURL.href ===
                 'https://sourcegraph.com/',
         })) {
-            const symbolResults = (await this.api.search(query)).map(result =>
-                resultToLocation({ result, sourcegraph: this.sourcegraph })
+            const symbolResults = (await this.api.search({ query })).map(
+                result =>
+                    resultToLocation({ result, sourcegraph: this.sourcegraph })
             )
 
             if (symbolResults.length > 0) {
@@ -668,7 +669,7 @@ export class Handler {
                         searchToken,
                         doc,
                         fileExts: this.fileExts,
-                    }).map(query => this.api.search(query))
+                    }).map(query => this.api.search({ query }))
                 )
             ).map(result =>
                 resultToLocation({ result, sourcegraph: this.sourcegraph })
@@ -693,9 +694,10 @@ export class Handler {
             } else {
                 const { repo, rev, path } = parseUri(doc.uri)
 
-                const r = await this.api.search(
-                    `repo:${repo}@${rev} file:${path} type:symbol ^` // ^ matches everything (can't leave out a query)
-                )
+                const r = await this.api.search({
+                    query: `repo:${repo}@${rev} file:${path} type:symbol ^`, // ^ matches everything (can't leave out a query)
+                    fileLocal: true,
+                })
                 editor.setDecorations(
                     this.sourcegraph.app.createDecorationType(),
                     r.map(v => ({


### PR DESCRIPTION
Otherwise this would throw an error on Sourcegraph instances that don't support `fileLocal` (none as of yet, working on a PR for it now).