### PR TITLE
Filter by fileLocal

### DIFF
--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -628,10 +628,22 @@ export class Handler {
                 this.sourcegraph.internal.sourcegraphURL.href ===
                 'https://sourcegraph.com/',
         })) {
-            const symbolResults = (await this.api.search({ query })).map(
-                result =>
+            const symbolResults = (await this.api.search({
+                query,
+                fileLocal: Boolean(
+                    this.sourcegraph.configuration
+                        .get()
+                        .get('feature.fileLocal')
+                ),
+            }))
+                .filter(
+                    result =>
+                        !result.fileLocal ||
+                        result.file === new URL(doc.uri).hash.replace(/^#/, '')
+                )
+                .map(result =>
                     resultToLocation({ result, sourcegraph: this.sourcegraph })
-            )
+                )
 
             if (symbolResults.length > 0) {
                 return sortByProximity({


### PR DESCRIPTION
When `feature.fileLocal` is set, file-local definitions will be filtered out.

File-local definitions are being added in (TODO link).