### PR TITLE
Avoid templating TypeScript, enables callbacks

### DIFF
--- a/languages.ts
+++ b/languages.ts
@@ -43,7 +43,7 @@ const lispStyle: CommentStyle = {
 // The set of languages come from https://madnight.github.io/githut/#/pull_requests/2018/4
 // The language names come from https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers
 // The extensions come from shared/src/languages.ts
-export const languages: LanguageSpec[] = [
+export const languageSpecs: LanguageSpec[] = [
     {
         handlerArgs: {
             languageID: 'typescript',

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -1,6 +1,6 @@
 import { activateBasicCodeIntel } from '../../package/lib'
 import * as sourcegraph from 'sourcegraph'
-import { languageSpecs } from './languages'
+import { languageSpecs } from '../../languages'
 
 export function activate(ctx: sourcegraph.ExtensionContext): void {
     // This is set to an individual language ID by the generator script.

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -1,9 +1,20 @@
 import { activateBasicCodeIntel } from '../../package/lib'
 import * as sourcegraph from 'sourcegraph'
-import * as spec from '../../languages'
+import { languageSpecs } from './languages'
 
 export function activate(ctx: sourcegraph.ExtensionContext): void {
-    for (const language of spec.languages) {
-        activateBasicCodeIntel(language.handlerArgs)(ctx)
+    // This is set to an individual language ID by the generator script.
+    const languageID = 'all'
+
+    if (languageID === 'all') {
+        for (const languageSpec of languageSpecs) {
+            activateBasicCodeIntel(languageSpec.handlerArgs)(ctx)
+        }
+    } else {
+        // TODO consider Record<LanguageID, LanguageSpec>
+        activateBasicCodeIntel(
+            languageSpecs.find(l => l.handlerArgs.languageID === languageID)!
+                .handlerArgs
+        )(ctx)
     }
 }

--- a/template/src/languages.ts
+++ b/template/src/languages.ts
@@ -1,0 +1,1 @@
+../../languages.ts

--- a/template/src/languages.ts
+++ b/template/src/languages.ts
@@ -1,1 +1,0 @@
-../../languages.ts


### PR DESCRIPTION
Previously, the generator would write out a TypeScript file using string interpolation, which only worked for arguments that were `JSON.stringify`able.

Now, the arguments are referred to directly, so callbacks can be added.