### PR TITLE
Work around Java bug in ctags

### DIFF
--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -659,7 +659,11 @@ export class Handler {
                 results: (await this.api.search(query)).filter(
                     result =>
                         !result.fileLocal ||
-                        result.file === new URL(doc.uri).hash.replace(/^#/, '')
+                        result.file ===
+                            new URL(doc.uri).hash.replace(/^#/, '') ||
+                        // https://github.com/universal-ctags/ctags/issues/1844
+                        (doc.languageId === 'java' &&
+                            result.symbolKind === 'ENUMMEMBER')
                 ),
             }).map(result =>
                 resultToLocation({ result, sourcegraph: this.sourcegraph })


### PR DESCRIPTION
(no need for review) Works around https://github.com/universal-ctags/ctags/issues/1844 by considering all enums in Java public. Previously, all enums in Java were private.