### PR TITLE
Remove same-file search query

### DIFF
--- a/package/src/handler.test.ts
+++ b/package/src/handler.test.ts
@@ -22,8 +22,6 @@ describe('search requests', () => {
                     text: 'token',
                 },
                 expectedSearchQueries: [
-                    // current file symbols
-                    '^token$ case:yes file:.(cpp)$ type:symbol repo:^github.com/foo/bar$@rev file:^file.cpp$',
                     // current repo symbols
                     '^token$ case:yes file:.(cpp)$ type:symbol repo:^github.com/foo/bar$@rev',
                     // all repo symbols

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -300,7 +300,6 @@ export function definitionQueries({
             fileExts,
         })
     return [
-        queryIn('current file'),
         queryIn('current repository'),
         ...(isSourcegraphDotCom ? [] : [queryIn('all repositories')]),
     ]

--- a/template/yarn.lock
+++ b/template/yarn.lock
@@ -2534,7 +2534,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.3:
+glob@^7.0.3, glob@^7.0.6, glob@^7.1.1, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==


### PR DESCRIPTION
Prior to this change, basic code intel would run 3 separate searches, returning early when one returns any results:

- Current file
- Current repository
- All repositories (unless on Sourcegraph.com)

This prevented basic code intel from showing valid results and letting the user choose (see https://github.com/sourcegraph/sourcegraph/issues/3234)

After this change, basic code intel will run 2 searches (skipping the current file search):

- Current repository
- All repositories (unless on Sourcegraph.com)

One reason why I didn't do this earlier is because j2d was very imprecise. Filtering by imports vastly improves this and tips the scale.

Fixes https://github.com/sourcegraph/sourcegraph/issues/3234 it'll show a choice after this change instead of jumping to the `Main` defined in the same file:

![image](https://user-images.githubusercontent.com/1387653/55606612-53598a80-572e-11e9-9676-facfed60ebf9.png)
