### PR TITLE
Add Objective-C

### DIFF
--- a/languages.ts
+++ b/languages.ts
@@ -336,6 +336,15 @@ export const languageSpecs: LanguageSpec[] = [
     },
     {
         handlerArgs: {
+            languageID: 'objective-c',
+            fileExts: ['m', 'mm', 'h'],
+            docstringIgnore: /^\s*@/,
+            commentStyle: { ...cStyle, lineRegex: /\/\/\/?\s?/ },
+        },
+        stylized: 'Objective-C',
+    },
+    {
+        handlerArgs: {
             languageID: 'rust',
             fileExts: ['rs', 'rs.in'],
             docstringIgnore: /^#/,


### PR DESCRIPTION
This is a draft because the ctags for Objective-C are pretty wonky. They contain a lot of colons and parent scopes:

![image](https://user-images.githubusercontent.com/1387653/56390331-a75d7800-61e0-11e9-8aaf-c781d033e5b1.png)

https://sourcegraph.com/github.com/react-native-community/react-native-webview/-/blob/ios/RNCWKWebView.m#L242

I don't intend to merge this in until that's been cleaned up or I figure out how to deal with it in basic-code-intel.