### PR TITLE
Add button to submit feedback

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/basic-code-intel",
-  "version": "6.0.15",
+  "version": "6.0.16",
   "description": "Common library for providing basic code intelligence in Sourcegraph extensions",
   "repository": {
     "type": "git",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,7 +1,7 @@
 import * as sourcegraph from 'sourcegraph'
 import { Handler, HandlerArgs, documentSelector } from './handler'
 
-export { Handler, HandlerArgs } from './handler'
+export { Handler, HandlerArgs, registerFeedbackButton } from './handler'
 
 // No-op for Sourcegraph versions prior to 3.0-preview
 const DUMMY_CTX = { subscriptions: { add: (_unsubscribable: any) => void 0 } }

--- a/template/package.json
+++ b/template/package.json
@@ -35,7 +35,6 @@
         "id": "feedback",
         "command": "feedback",
         "title": "Submit basic code intel feedback",
-        "command": "open",
         "commandArguments": [
           "https://docs.google.com/forms/d/e/1FAIpQLSfmn4M3nVj6R5m8UuAor_4ft8IMhieND_Uu8AlerhGO7X9C9w/viewform"
         ],

--- a/template/package.json
+++ b/template/package.json
@@ -30,9 +30,28 @@
           "label": "References: Search mode",
           "description": "Results come from text search and heuristics. (Language server mode is not available for $LANG.)/(To use a language server for precise results, ...)"
         }
+      },
+      {
+        "id": "feedback",
+        "command": "feedback",
+        "title": "Submit basic code intel feedback",
+        "command": "open",
+        "commandArguments": [
+          "https://docs.google.com/forms/d/e/1FAIpQLSfmn4M3nVj6R5m8UuAor_4ft8IMhieND_Uu8AlerhGO7X9C9w/viewform"
+        ],
+        "actionItem": {
+          "description": "Submit basic code intel feedback",
+          "iconURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTExLjk5IDJDNi40NyAyIDIgNi40OCAyIDEyczQuNDcgMTAgOS45OSAxMEMxNy41MiAyMiAyMiAxNy41MiAyMiAxMlMxNy41MiAyIDExLjk5IDJ6TTEyIDIwYy00LjQyIDAtOC0zLjU4LTgtOHMzLjU4LTggOC04IDggMy41OCA4IDgtMy41OCA4LTggOHptMy41LTljLjgzIDAgMS41LS42NyAxLjUtMS41UzE2LjMzIDggMTUuNSA4IDE0IDguNjcgMTQgOS41cy42NyAxLjUgMS41IDEuNXptLTcgMGMuODMgMCAxLjUtLjY3IDEuNS0xLjVTOS4zMyA4IDguNSA4IDcgOC42NyA3IDkuNSA3LjY3IDExIDguNSAxMXptMy41IDYuNWMyLjMzIDAgNC4zMS0xLjQ2IDUuMTEtMy41SDYuODljLjggMi4wNCAyLjc4IDMuNSA1LjExIDMuNXoiLz48L3N2Zz4="
+        }
       }
     ],
     "menus": {
+      "editor/title": [
+        {
+          "action": "feedback",
+          "when": "showFeedback"
+        }
+      ],
       "panel/toolbar": [
         {
           "action": "impreciseResults",

--- a/template/package.json
+++ b/template/package.json
@@ -33,13 +33,13 @@
       },
       {
         "id": "feedback",
-        "command": "feedback",
-        "title": "Submit basic code intel feedback",
+        "command": "open",
+        "title": "Submit code intel feedback",
         "commandArguments": [
-          "https://docs.google.com/forms/d/e/1FAIpQLSfmn4M3nVj6R5m8UuAor_4ft8IMhieND_Uu8AlerhGO7X9C9w/viewform"
+          "${get(context, `codeIntel.feedbackLink`)}"
         ],
         "actionItem": {
-          "description": "Submit basic code intel feedback",
+          "description": "Submit code intel feedback",
           "iconURL": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMCAwaDI0djI0SDB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTExLjk5IDJDNi40NyAyIDIgNi40OCAyIDEyczQuNDcgMTAgOS45OSAxMEMxNy41MiAyMiAyMiAxNy41MiAyMiAxMlMxNy41MiAyIDExLjk5IDJ6TTEyIDIwYy00LjQyIDAtOC0zLjU4LTgtOHMzLjU4LTggOC04IDggMy41OCA4IDgtMy41OCA4LTggOHptMy41LTljLjgzIDAgMS41LS42NyAxLjUtMS41UzE2LjMzIDggMTUuNSA4IDE0IDguNjcgMTQgOS41cy42NyAxLjUgMS41IDEuNXptLTcgMGMuODMgMCAxLjUtLjY3IDEuNS0xLjVTOS4zMyA4IDguNSA4IDcgOC42NyA3IDkuNSA3LjY3IDExIDguNSAxMXptMy41IDYuNWMyLjMzIDAgNC4zMS0xLjQ2IDUuMTEtMy41SDYuODljLjggMi4wNCAyLjc4IDMuNSA1LjExIDMuNXoiLz48L3N2Zz4="
         }
       }

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -30,6 +30,9 @@ function activateWithArgs(
     const h = new Handler({ ...args, sourcegraph })
 
     sourcegraph.internal.updateContext({ isImprecise: true })
+    if (sourcegraph.configuration.get().get('basicCodeIntel.showFeedback')) {
+        sourcegraph.internal.updateContext({ showFeedback: true })
+    }
 
     ctx.subscriptions.add(
         sourcegraph.languages.registerHoverProvider(

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -1,8 +1,7 @@
-import { Handler, HandlerArgs } from '../../package/lib'
+import { Handler, HandlerArgs, registerFeedbackButton } from '../../package/lib'
 import * as sourcegraph from 'sourcegraph'
 import { languageSpecs } from '../../languages'
 import { documentSelector } from '../../package/lib/handler'
-import { concat, of } from 'rxjs'
 
 const DUMMY_CTX = { subscriptions: { add: (_unsubscribable: any) => void 0 } }
 
@@ -32,23 +31,13 @@ function activateWithArgs(
 
     sourcegraph.internal.updateContext({ isImprecise: true })
 
-    if (sourcegraph.configuration.get().get('basicCodeIntel.showFeedback')) {
-        concat(
-            // Update the context once upon page load...
-            of(undefined),
-            // ...and whenever a document is opened.
-            sourcegraph.workspace.onDidOpenTextDocument
-        ).subscribe(document => {
-            sourcegraph.internal.updateContext({
-                showFeedback: true,
-                'codeIntel.feedbackLink': feedbackLink({
-                    currentFile: document && document.uri,
-                    language: args.languageID,
-                    kind: 'Default',
-                }).href,
-            })
+    ctx.subscriptions.add(
+        registerFeedbackButton({
+            languageID: args.languageID,
+            sourcegraph,
+            isPrecise: false,
         })
-    }
+    )
 
     ctx.subscriptions.add(
         sourcegraph.languages.registerHoverProvider(
@@ -74,24 +63,4 @@ function activateWithArgs(
             }
         )
     )
-}
-
-function feedbackLink({
-    currentFile,
-    language,
-    kind,
-}: {
-    currentFile?: string
-    language: string
-    kind: 'Default' | 'Precise'
-}): URL {
-    const url = new URL(
-        'https://docs.google.com/forms/d/e/1FAIpQLSfmn4M3nVj6R5m8UuAor_4ft8IMhieND_Uu8AlerhGO7X9C9w/viewform?usp=pp_url'
-    )
-    if (currentFile) {
-        url.searchParams.append('entry.1135698969', currentFile)
-    }
-    url.searchParams.append('entry.55312909', language)
-    url.searchParams.append('entry.1824476739', kind)
-    return url
 }


### PR DESCRIPTION
This shows a little smiley face icon in the toolbar for submitting feedback about basic code intel (links to a Google Form):

![image](https://user-images.githubusercontent.com/1387653/56475183-d9b5e200-6439-11e9-8fa0-93600b917889.png)

Global/org/user setting:

```
  // Shows the little smiley face icon in the toolbar for submitting feedback about basic code intel.
  "basicCodeIntel.showFeedback": true,
```

The plan is to turn this on for the Sourcegraph org (teammates only) to determine in which areas basic code intel could most improve and have the most benefit. 99% of customers in the pipeline use basic code intel, so this aligns our experience with theirs.