### PR TITLE
Bump basic-code-intel 6.0.17

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/basic-code-intel",
-  "version": "6.0.16",
+  "version": "6.0.17",
   "description": "Common library for providing basic code intelligence in Sourcegraph extensions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previous release build had a `<reference...` comment at the top of https://unpkg.com/@sourcegraph/basic-code-intel@6.0.16/lib/api.d.ts which caused the sourcegraph-typescript build to fail https://buildkite.com/sourcegraph/sourcegraph-typescript/builds/1621#be145b1a-0e75-49f1-9f69-11c4b5c4be8f/19-89

This was because I had the `sourcegraph` package linked locally.