### PR TITLE
Add toggle for global symbol search

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off

--- a/package/src/handler.test.ts
+++ b/package/src/handler.test.ts
@@ -13,6 +13,7 @@ describe('search requests', () => {
         interface DefinitionTest {
             doc: TextDocument
             expectedSearchQueries: string[]
+            enableGlobalSymbolSearch: boolean
         }
         const tests: DefinitionTest[] = [
             {
@@ -21,11 +22,24 @@ describe('search requests', () => {
                     languageId: 'cpp',
                     text: 'token',
                 },
+                enableGlobalSymbolSearch: true,
                 expectedSearchQueries: [
                     // current repo symbols
                     '^token$ case:yes file:.(cpp)$ type:symbol repo:^github.com/foo/bar$@rev',
                     // all repo symbols
                     '^token$ case:yes file:.(cpp)$ type:symbol',
+                ],
+            },
+            {
+                doc: {
+                    uri: 'git://github.com/foo/bar?rev#file.cpp',
+                    languageId: 'cpp',
+                    text: 'token',
+                },
+                enableGlobalSymbolSearch: false,
+                expectedSearchQueries: [
+                    // current repo symbols
+                    '^token$ case:yes file:.(cpp)$ type:symbol repo:^github.com/foo/bar$@rev',
                 ],
             },
         ]
@@ -36,7 +50,7 @@ describe('search requests', () => {
                     searchToken: 'token',
                     doc: test.doc,
                     fileExts: ['cpp'],
-                    enableGlobalSymbolSearch: false,
+                    enableGlobalSymbolSearch: test.enableGlobalSymbolSearch,
                 }),
                 test.expectedSearchQueries
             )

--- a/package/src/handler.test.ts
+++ b/package/src/handler.test.ts
@@ -36,7 +36,7 @@ describe('search requests', () => {
                     searchToken: 'token',
                     doc: test.doc,
                     fileExts: ['cpp'],
-                    isSourcegraphDotCom: false,
+                    enableGlobalSymbolSearch: false,
                 }),
                 test.expectedSearchQueries
             )


### PR DESCRIPTION
This adds a setting to disable global symbol search:

```json
  "codeIntel.globalSymbolSearch": false
```

Defaults to **`true`** (the current behavior).

The downside is that when this is `false`, cross-repository go-to-definition will stop working.

See https://sourcegraph.slack.com/archives/C08JA8Q1H/p1563496178024000?thread_ts=1563233415.015100&cid=C08JA8Q1H