### PR TITLE
Also generate sourcegraph-python

### DIFF
--- a/generator/src/main.ts
+++ b/generator/src/main.ts
@@ -11,7 +11,7 @@ function sourcegraphID(name: string): string {
     return name in toID ? toID[name] : name
 }
 
-const doNotGenerate = ['python', 'typescript', 'go']
+const doNotGenerate = ['typescript', 'go']
 
 function main(): void {
     const args = yargs


### PR DESCRIPTION
Because of performance issues, the Python language server has been disabled for months and we do not recommend using it. That makes http://github.com/sourcegraph/sourcegraph-python a no-op wrapper around basic-code-intel, so we might as well generate it from this repo.