### PR TITLE
Export more functions from the top level

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/basic-code-intel",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "description": "Common library for providing basic code intelligence in Sourcegraph extensions",
   "repository": {
     "type": "git",

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -8,4 +8,5 @@ export {
     Maybe,
     MaybeProviders,
     noopMaybeProviders,
+    mkIsLSIFAvailable,
 } from './lsif'

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -9,4 +9,8 @@ export {
     MaybeProviders,
     noopMaybeProviders,
     mkIsLSIFAvailable,
+    hover,
+    definition,
+    references,
+    Providers,
 } from './lsif'

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -116,7 +116,7 @@ export const mkIsLSIFAvailable = () => {
     }
 }
 
-async function hover(
+export async function hover(
     doc: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ): Promise<sourcegraph.Hover | null> {
@@ -132,7 +132,7 @@ async function hover(
     return convertHover(sourcegraph, hover)
 }
 
-async function definition(
+export async function definition(
     doc: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ): Promise<sourcegraph.Definition | null> {
@@ -155,7 +155,7 @@ async function definition(
     )
 }
 
-async function references(
+export async function references(
     doc: sourcegraph.TextDocument,
     position: sourcegraph.Position
 ): Promise<sourcegraph.Location[] | null> {


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph-typescript/pull/229 could make use of some more functions from basic-code-intel to avoid needing to unwrap values as much and to avoid submodule imports.

See https://github.com/sourcegraph/sourcegraph-typescript/pull/229#discussion_r312515617