### PR TITLE
Interpret a non-OK response as no LSIF available

### DIFF
--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -109,7 +109,7 @@ export const mkIsLSIFAvailable = () => {
                 }),
             })
             if (!response.ok) {
-                throw new Error(`LSIF /exists returned ${response.statusText}`)
+                return false
             }
             return await response.json()
         })()


### PR DESCRIPTION
This is a quick fix because code intel appears to be broken right now.