### PR TITLE
Decode the fragment

### DIFF
--- a/package/src/api.ts
+++ b/package/src/api.ts
@@ -170,7 +170,7 @@ export class API {
             }
           }`
 
-        const { repo, rev, path } = parseUri(loc.uri.toString())
+        const { repo, rev, path } = parseUri(loc.uri)
         const respObj = await queryGraphQL({
             query: graphqlQuery,
             vars: { repo, rev, path },
@@ -189,26 +189,12 @@ export class API {
 }
 
 export function parseUri(
-    uri: string
+    uri: URL
 ): { repo: string; rev: string; path: string } {
-    if (!uri.startsWith('git://')) {
-        throw new Error('unexpected uri format: ' + uri)
-    }
-    const repoRevPath = uri.substr('git://'.length)
-    const i = repoRevPath.indexOf('?')
-    if (i < 0) {
-        throw new Error('unexpected uri format: ' + uri)
-    }
-    const revPath = repoRevPath.substr(i + 1)
-    const j = revPath.indexOf('#')
-    if (j < 0) {
-        throw new Error('unexpected uri format: ' + uri)
-    }
-    const path = revPath.substr(j + 1)
     return {
-        repo: repoRevPath.substring(0, i),
-        rev: revPath.substring(0, j),
-        path: path,
+        repo: uri.host + uri.pathname,
+        rev: decodeURIComponent(uri.search.slice(1)), // strip the leading ?
+        path: decodeURIComponent(uri.hash.slice(1)), // strip the leading #
     }
 }
 

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -80,7 +80,7 @@ function makeQuery({
             console.error('bad searchType', searchType)
     }
 
-    const { repo, rev, path } = parseUri(currentFileUri)
+    const { repo, rev, path } = parseUri(new URL(currentFileUri))
     switch (scope) {
         case 'current file':
             terms.push(`repo:^${repo}$@${rev}`)
@@ -808,7 +808,7 @@ export class Handler {
             if (!editor) {
                 console.log('NO EDITOR')
             } else {
-                const { repo, rev, path } = parseUri(doc.uri)
+                const { repo, rev, path } = parseUri(new URL(doc.uri))
 
                 // ^ matches everything (can't leave out a query)
                 const r = await this.api.search(


### PR DESCRIPTION
The problem here was that basic-code-intel was not decoding the URL fragment (the part after the `#`), which broke code intel on files with special characters.

Fixes https://github.com/sourcegraph/sourcegraph/issues/6042