### PR TITLE
Remove codeIntel.globalSymbolSearch

### DIFF
--- a/package/src/handler.test.ts
+++ b/package/src/handler.test.ts
@@ -14,7 +14,6 @@ describe('search requests', () => {
         interface DefinitionTest {
             doc: TextDocument
             expectedSearchQueries: string[]
-            enableGlobalSymbolSearch: boolean
         }
         const tests: DefinitionTest[] = [
             {
@@ -23,24 +22,11 @@ describe('search requests', () => {
                     languageId: 'cpp',
                     text: 'token',
                 }),
-                enableGlobalSymbolSearch: true,
                 expectedSearchQueries: [
                     // current repo symbols
                     '^token$ case:yes file:\\.(cpp)$ type:symbol repo:^github.com/foo/bar$@rev',
                     // all repo symbols
                     '^token$ case:yes file:\\.(cpp)$ type:symbol',
-                ],
-            },
-            {
-                doc: createStubTextDocument({
-                    uri: 'git://github.com/foo/bar?rev#file.cpp',
-                    languageId: 'cpp',
-                    text: 'token',
-                }),
-                enableGlobalSymbolSearch: false,
-                expectedSearchQueries: [
-                    // current repo symbols
-                    '^token$ case:yes file:\\.(cpp)$ type:symbol repo:^github.com/foo/bar$@rev',
                 ],
             },
         ]
@@ -51,7 +37,7 @@ describe('search requests', () => {
                     searchToken: 'token',
                     doc: test.doc,
                     fileExts: ['cpp'],
-                    enableGlobalSymbolSearch: test.enableGlobalSymbolSearch,
+                    isSourcegraphDotCom: false,
                 }),
                 test.expectedSearchQueries
             )


### PR DESCRIPTION
Now that symbol search is indexed, it's no longer a perf concern.

Resolves https://github.com/sourcegraph/sourcegraph/issues/6755
Reverts https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/123