### PR TITLE
LSIF GraphQL API

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -48,6 +48,7 @@
     "@types/lodash": "4.14.149",
     "@types/mocha": "5.2.7",
     "@types/node": "10.12.12",
+    "@types/semver": "^6.2.0",
     "lnfs-cli": "^2.1.0",
     "mkdirp": "^0.5.1",
     "mocha": "^5.2.0",
@@ -62,6 +63,7 @@
   "dependencies": {
     "lodash": "^4.17.11",
     "rxjs": "^6.3.3",
+    "semver": "^6.3.0",
     "sourcegraph": "^23.0.1",
     "vscode-languageserver-types": "^3.14.0"
   },

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -745,7 +745,7 @@ export class Handler {
             )
 
             if (symbolResults.length > 0) {
-                const locations= sortByProximity({
+                const locations = sortByProximity({
                     currentLocation: doc.uri,
                     locations: symbolResults,
                 })

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -672,12 +672,6 @@ export class Handler {
             docstringIgnore: this.docstringIgnore,
         })
 
-        console.debug('Received hover', {
-            source: 'Search',
-            line: pos.line,
-            character: pos.character,
-        })
-
         return {
             contents: {
                 kind: this.sourcegraph.MarkupKind.Markdown,
@@ -745,16 +739,10 @@ export class Handler {
             )
 
             if (symbolResults.length > 0) {
-                const locations = sortByProximity({
+                return sortByProximity({
                     currentLocation: doc.uri,
                     locations: symbolResults,
                 })
-                console.debug(`Received ${locations.length} definitions`, {
-                    source: 'Search',
-                    line: pos.line,
-                    character: pos.character,
-                })
-                return locations
             }
         }
 
@@ -775,7 +763,7 @@ export class Handler {
         }
         const searchToken = tokenResult.searchToken
 
-        const locations = sortByProximity({
+        return sortByProximity({
             currentLocation: doc.uri,
             locations: flatten(
                 await Promise.all(
@@ -792,12 +780,6 @@ export class Handler {
                 resultToLocation({ result, sourcegraph: this.sourcegraph })
             ),
         })
-        console.debug(`Received ${locations.length} references`, {
-            source: 'Search',
-            line: pos.line,
-            character: pos.character,
-        })
-        return locations
     }
 
     /**

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -672,6 +672,12 @@ export class Handler {
             docstringIgnore: this.docstringIgnore,
         })
 
+        console.debug('Received hover', {
+            source: 'Search',
+            line: pos.line,
+            character: pos.character,
+        })
+
         return {
             contents: {
                 kind: this.sourcegraph.MarkupKind.Markdown,
@@ -739,10 +745,16 @@ export class Handler {
             )
 
             if (symbolResults.length > 0) {
-                return sortByProximity({
+                const locations= sortByProximity({
                     currentLocation: doc.uri,
                     locations: symbolResults,
                 })
+                console.debug(`Received ${locations.length} definitions`, {
+                    source: 'Search',
+                    line: pos.line,
+                    character: pos.character,
+                })
+                return locations
             }
         }
 
@@ -763,7 +775,7 @@ export class Handler {
         }
         const searchToken = tokenResult.searchToken
 
-        return sortByProximity({
+        const locations = sortByProximity({
             currentLocation: doc.uri,
             locations: flatten(
                 await Promise.all(
@@ -780,6 +792,12 @@ export class Handler {
                 resultToLocation({ result, sourcegraph: this.sourcegraph })
             ),
         })
+        console.debug(`Received ${locations.length} references`, {
+            source: 'Search',
+            line: pos.line,
+            character: pos.character,
+        })
+        return locations
     }
 
     /**

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -127,7 +127,6 @@ export const mkIsLSIFAvailable = () => {
         })()
 
         lsifDocs.set(doc.uri, hasLSIFPromise)
-
         return hasLSIFPromise
     }
 }
@@ -146,11 +145,6 @@ export async function hover(
         return undefined
     }
 
-    console.debug('Received hover', {
-        source: 'HTTP API',
-        line: position.line,
-        character: position.character,
-    })
     return { value: convertHover(sourcegraph, hover) }
 }
 
@@ -171,12 +165,6 @@ export async function definition(
     if (locations.length === 0) {
         return undefined
     }
-
-    console.debug(`Received ${locations.length} definitions`, {
-        source: 'HTTP API',
-        line: position.line,
-        character: position.character,
-    })
 
     return {
         value: convertLocations(
@@ -203,12 +191,6 @@ export async function references(
     if (locations.length === 0) {
         return []
     }
-
-    console.debug(`Received ${locations.length} references`, {
-        source: 'HTTP API',
-        line: position.line,
-        character: position.character,
-    })
 
     return convertLocations(
         sourcegraph,
@@ -472,13 +454,7 @@ async function definitionGraphQL(
         return undefined
     }
 
-    const nodes = lsifObj.definitions.nodes
-    console.debug(`Received ${nodes.length} definitions`, {
-        source: 'GraphQL API',
-        line: position.line,
-        character: position.character,
-    })
-    return { value: nodes.map(nodeToLocation) }
+    return { value: lsifObj.definitions.nodes.map(nodeToLocation) }
 }
 
 async function referencesGraphQL(
@@ -529,13 +505,7 @@ async function referencesGraphQL(
         return undefined
     }
 
-    const nodes = lsifObj.references.nodes
-    console.debug(`Received ${nodes.length} references`, {
-        source: 'GraphQL API',
-        line: position.line,
-        character: position.character,
-    })
-    return { value: nodes.map(nodeToLocation) }
+    return { value: lsifObj.references.nodes.map(nodeToLocation) }
 }
 
 async function hoverGraphQL(
@@ -582,17 +552,15 @@ async function hoverGraphQL(
         return undefined
     }
 
-    const contents = {
-        value: lsifObj.hover.markdown.text,
-        kind: sourcegraph.MarkupKind.Markdown,
+    return {
+        value: {
+            contents: {
+                value: lsifObj.hover.markdown.text,
+                kind: sourcegraph.MarkupKind.Markdown,
+            },
+            range: lsifObj.hover.range,
+        },
     }
-
-    console.debug('Received hover', {
-        source: 'GraphQL API',
-        line: position.line,
-        character: position.character,
-    })
-    return { value: { contents, range: lsifObj.hover.range } }
 }
 
 async function queryLSIFGraphQL<T>({

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -492,7 +492,19 @@ async function hoverGraphQL(
                     blob(path: $path) {
                         lsif {
                             hover(line: $line, character: $character) {
-                                text
+                                markdown {
+                                    text
+                                }
+                                range {
+                                    start {
+                                        line
+                                        character
+                                    }
+                                    end {
+                                        line
+                                        character
+                                    }
+                                }
                             }
                         }
                     }
@@ -501,7 +513,9 @@ async function hoverGraphQL(
         }
     `
 
-    const lsifObj = await queryLSIFGraphQL<{ hover: { text: string } }>({
+    const lsifObj = await queryLSIFGraphQL<{
+        hover: { markdown: { text: string }; range: sourcegraph.Range }
+    }>({
         doc,
         query,
         position,
@@ -511,9 +525,10 @@ async function hoverGraphQL(
         lsifObj && {
             value: {
                 contents: {
-                    value: lsifObj.hover.text,
+                    value: lsifObj.hover.markdown.text,
                     kind: sourcegraph.MarkupKind.Markdown,
                 },
+                range: lsifObj.hover.range,
             },
         }
     )

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -4,11 +4,17 @@ import { convertLocations, convertHover } from './lsp-conversion'
 import { queryGraphQL } from './api'
 import { compareVersion } from './versions'
 
-/** The date that the LSIF GraphQL API resolvers became available. */
-const GRAPHQL_API_MINIMUM_DATE = '2019-12-20'
+/**
+ * The date that the LSIF GraphQL API resolvers became available.
+ *
+ * Specifically, ensure that the commit 34e6a67ecca30afb4a5d8d200fc88a724d3c4ac5
+ * exists, as there is a bad performance issue prior to that when a force push
+ * removes commits from the codehost for which we have LSIF data.
+ */
+const GRAPHQL_API_MINIMUM_DATE = '2020-01-08'
 
 /** The version that the LSIF GraphQL API resolvers became available. */
-const GRAPHQL_API_MINIMUM_VERSION = '3.11.0'
+const GRAPHQL_API_MINIMUM_VERSION = '3.12.0'
 
 function repositoryFromDoc(doc: sourcegraph.TextDocument): string {
     const url = new URL(doc.uri)

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -144,7 +144,6 @@ export async function hover(
     if (!hover) {
         return undefined
     }
-
     return { value: convertHover(sourcegraph, hover) }
 }
 
@@ -165,7 +164,6 @@ export async function definition(
     if (locations.length === 0) {
         return undefined
     }
-
     return {
         value: convertLocations(
             sourcegraph,
@@ -191,7 +189,6 @@ export async function references(
     if (locations.length === 0) {
         return []
     }
-
     return convertLocations(
         sourcegraph,
         locations.map(r => ({ ...r, uri: setPath(doc, r.uri) }))

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -6,7 +6,7 @@ import { queryGraphQL } from './api'
 import { compareVersion } from './versions'
 
 /** The date that the LSIF GraphQL API resolvers became available. */
-const GRAPHQL_API_MINIMUM_DATE = '2019-12-01'
+const GRAPHQL_API_MINIMUM_DATE = '2019-12-12'
 
 /** The version that the LSIF GraphQL API resolvers became available. */
 const GRAPHQL_API_MINIMUM_VERSION = '3.11.0'

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -81,6 +81,7 @@ export const mkIsLSIFAvailable = () => {
     const lsifDocs = new Map<string, Promise<boolean>>()
     return (doc: sourcegraph.TextDocument): Promise<boolean> => {
         if (!sourcegraph.configuration.get().get('codeIntel.lsif')) {
+            console.log('LSIF is not enabled in global settings')
             return Promise.resolve(false)
         }
 
@@ -303,11 +304,13 @@ export const noopMaybeProviders = {
 export function initLSIF(): MaybeProviders {
     const provider = (async () => {
         if (await supportsGraphQL()) {
-            console.log('Using LSIF GraphQL API')
+            console.log('Sourcegraph instance supports LSIF GraphQL API')
             return initGraphQL()
         }
 
-        console.log('Using LSIF HTTP API')
+        console.log(
+            'Sourcegraph instance does not support LSIF GraphQL API, falling back to HTTP API'
+        )
         return initHTTP()
     })()
 
@@ -376,6 +379,7 @@ function initGraphQL(): MaybeProviders {
         pos: sourcegraph.Position
     ): Promise<Maybe<R>> => {
         if (!sourcegraph.configuration.get().get('codeIntel.lsif')) {
+            console.log('LSIF is not enabled in global settings')
             return undefined
         }
 

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -5,7 +5,7 @@ import { queryGraphQL } from './api'
 import { compareVersion } from './versions'
 
 /** The date that the LSIF GraphQL API resolvers became available. */
-const GRAPHQL_API_MINIMUM_DATE = '2019-12-12'
+const GRAPHQL_API_MINIMUM_DATE = '2019-12-20'
 
 /** The version that the LSIF GraphQL API resolvers became available. */
 const GRAPHQL_API_MINIMUM_VERSION = '3.11.0'

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -9,7 +9,7 @@ import { compareVersion } from './versions'
 const GRAPHQL_API_MINIMUM_DATE = '2019-12-01'
 
 /** The version that the LSIF GraphQL API resolvers became available. */
-const GRAPHQL_API_MINIMUM_VERSION = '3.11'
+const GRAPHQL_API_MINIMUM_VERSION = '3.11.0'
 
 function repositoryFromDoc(doc: sourcegraph.TextDocument): string {
     const url = new URL(doc.uri)

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -1,5 +1,4 @@
 import * as sourcegraph from 'sourcegraph'
-
 import * as LSP from 'vscode-languageserver-types'
 import { convertLocations, convertHover } from './lsp-conversion'
 import { queryGraphQL } from './api'

--- a/package/src/lsif.ts
+++ b/package/src/lsif.ts
@@ -211,10 +211,10 @@ export async function references(
         character: position.character,
     })
 
-    return  convertLocations(
-            sourcegraph,
-            locations.map(r => ({ ...r, uri: setPath(doc, r.uri) }))
-        )
+    return convertLocations(
+        sourcegraph,
+        locations.map(r => ({ ...r, uri: setPath(doc, r.uri) }))
+    )
 }
 
 /**

--- a/package/src/versions.test.ts
+++ b/package/src/versions.test.ts
@@ -1,0 +1,77 @@
+import * as assert from 'assert'
+import { compareVersion } from './versions'
+
+describe('compareVersions', () => {
+    it('should return enabledForDev flag when product version is dev', () => {
+        for (const value of [true, false]) {
+            const enabled = compareVersion({
+                productVersion: 'dev',
+                minimumDate: '',
+                minimumVersion: '',
+                enableForDev: value,
+            })
+
+            assert.equal(enabled, value)
+        }
+    })
+
+    it('should compare semantic versions', () => {
+        const tests: {
+            productVersion: string
+            enabled: boolean
+        }[] = [
+            {
+                productVersion: '1.2.3',
+                enabled: true,
+            },
+            {
+                productVersion: '1.2.4',
+                enabled: true,
+            },
+            {
+                productVersion: '1.2.2',
+                enabled: false,
+            },
+        ]
+
+        for (const test of tests) {
+            const enabled = compareVersion({
+                productVersion: test.productVersion,
+                minimumDate: '',
+                minimumVersion: '1.2.3',
+            })
+
+            assert.equal(enabled, test.enabled)
+        }
+    })
+
+    it('should compare build strings', () => {
+        const tests: {
+            productVersion: string
+            enabled: boolean
+        }[] = [
+            {
+                productVersion: '12345_2019-12-04_deadbee',
+                enabled: true,
+            },
+            {
+                productVersion: '12345_2019-12-05_deadbee',
+                enabled: true,
+            },
+            {
+                productVersion: '12345_2019-12-03_deadbee',
+                enabled: false,
+            },
+        ]
+
+        for (const test of tests) {
+            const enabled = compareVersion({
+                productVersion: test.productVersion,
+                minimumDate: '2019-12-04',
+                minimumVersion: '',
+            })
+
+            assert.equal(enabled, test.enabled)
+        }
+    })
+})

--- a/package/src/versions.ts
+++ b/package/src/versions.ts
@@ -1,0 +1,46 @@
+import * as semver from 'semver'
+
+/**
+ * Compare a product version against a minimum product version
+ * or build date. The minimum product version should be a semantic
+ * version. The minimum build date should be a YYYY-MM-DD string.
+ *
+ * The supplied minimums should be the version or date for which
+ * a feature is **guaranteed** to be available. This is especially
+ * necessary for dates, where where releases earlier in the day
+ * may not have the feature, but releases later in the day do. In
+ * this case, the minimum date should be the day after the feature
+ * was introduced.
+ *
+ * @param args Parameter bag.
+ */
+export function compareVersion({
+    productVersion,
+    minimumDate,
+    minimumVersion,
+    enableForDev = true,
+}: {
+    /** The current product version. */
+    productVersion: string
+    /** The minimum date of the build string. */
+    minimumDate: string
+    /** THe minimum release version. */
+    minimumVersion: string
+    /** Whether to return true in development. */
+    enableForDev?: boolean
+}): boolean {
+    if (productVersion === 'dev') {
+        return enableForDev
+    }
+
+    if (semver.valid(productVersion)) {
+        return semver.satisfies(productVersion, `>=${minimumVersion}`)
+    }
+
+    const m = productVersion.match(/^\d+_(\d{4}-\d{2}-\d{2})_[a-z0-9]{7}$/)
+    if (m === null) {
+        throw new Error(`Unexpected product version '${productVersion}'.`)
+    }
+
+    return m[1].localeCompare(minimumDate) >= 0
+}

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -185,6 +185,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.12.tgz#e15a9d034d9210f00320ef718a50c4a799417c47"
   integrity sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==
 
+"@types/semver@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
+  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
+
 "@types/sinon@7.0.13":
   version "7.0.13"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.13.tgz#ca039c23a9e27ebea53e0901ef928ea2a1a6d313"
@@ -2048,6 +2053,11 @@ safe-regex@^1.1.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
+  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 set-blocking@^2.0.0:
   version "2.0.0"

--- a/template/src/extension.ts
+++ b/template/src/extension.ts
@@ -9,10 +9,14 @@ export function activate(ctx: sourcegraph.ExtensionContext = DUMMY_CTX): void {
     // This is set to an individual language ID by the generator script.
     const languageID = 'all'
 
+    // LSIF is not language-specific, and we only want to initialize it once.
+    // Otherwise we will make a flurry of calls to the frontend to check if
+    // LSIF is enabled.
+    const lsif = initLSIF()
+
     for (const languageSpec of languageID === 'all'
         ? languageSpecs
         : [languageSpecs.find(l => l.handlerArgs.languageID === languageID)!]) {
-        const lsif = initLSIF()
         const handler = new Handler({
             ...languageSpec.handlerArgs,
             sourcegraph,


### PR DESCRIPTION
This is an update to support the GraphQL API for LSIF data (once https://github.com/sourcegraph/sourcegraph/pull/7021 is merged).

The version check might be wonky: not sure a better way than to do it date-based. That will allow a transition period where both APIs are available (for at least one day). The date string there is currently wrong (obviously) and must be updated after the dependent PR is merged.