### PR TITLE
Fall back to fuzzy because LSIF data might be sparse

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sourcegraph/basic-code-intel",
-  "version": "7.0.9",
+  "version": "7.0.10",
   "description": "Common library for providing basic code intelligence in Sourcegraph extensions",
   "repository": {
     "type": "git",

--- a/package/src/handler.ts
+++ b/package/src/handler.ts
@@ -749,12 +749,9 @@ export class Handler {
         return []
     }
 
-    async references(
-        doc: TextDocument,
-        pos: Position
-    ): Promise<Location[] | null> {
+    async references(doc: TextDocument, pos: Position): Promise<Location[]> {
         if (doc.text === undefined) {
-            return null
+            return []
         }
         const tokenResult = findSearchToken({
             text: doc.text,
@@ -762,7 +759,7 @@ export class Handler {
             lineRegex: this.commentStyle && this.commentStyle.lineRegex,
         })
         if (!tokenResult) {
-            return null
+            return []
         }
         const searchToken = tokenResult.searchToken
 

--- a/package/src/lsp-conversion.ts
+++ b/package/src/lsp-conversion.ts
@@ -21,11 +21,8 @@ export const convertRange = (
 
 export function convertHover(
     sourcegraph: typeof import('sourcegraph'),
-    hover: LSP.Hover | null
-): sourcegraph.Hover | null {
-    if (!hover) {
-        return null
-    }
+    hover: LSP.Hover
+): sourcegraph.Hover {
     const contents = Array.isArray(hover.contents)
         ? hover.contents
         : [hover.contents]
@@ -69,13 +66,7 @@ export const convertLocation = (
 
 export function convertLocations(
     sourcegraph: typeof import('sourcegraph'),
-    locationOrLocations: LSP.Location | LSP.Location[] | null
-): sourcegraph.Location[] | null {
-    if (!locationOrLocations) {
-        return null
-    }
-    const locations = Array.isArray(locationOrLocations)
-        ? locationOrLocations
-        : [locationOrLocations]
+    locations: LSP.Location[]
+): sourcegraph.Location[] {
     return locations.map(location => convertLocation(sourcegraph, location))
 }


### PR DESCRIPTION
Implements [RFC 49 REVIEW: Fallback when LSIF data doesn't exist](https://docs.google.com/document/d/1qONlFV3mkNZLfO3KyYlEApez1tLYt3BkOAqJxvUeuRk/edit)

Prior to this change, if there was no LSIF results for a code intel request, no code intel would be presented to the user.

After this change:

- Hovers: if LSIF returns no hover, it'll fall back to basic-code-intel
- Definitions: if LSIF returns no definition, it'll fall back to basic-code-intel
- References: **both** LSIF **and** text search results are shown, LSIF first

Related: [RFC 89 WIP: Precise Code Intel Confidence](https://docs.google.com/document/d/1aVbkz-yIBHNdrubkYq9vUrVa7_yUUVSPMmwvy52hRXc/edit#heading=h.trqab8y0kufp) outlines a plan to make the source of code intel data more transparent to the user so they understand why they're seeing fuzzy/precise results.